### PR TITLE
Upgrade to Version 5.1.44

### DIFF
--- a/nscp.nuspec
+++ b/nscp.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>nscp</id>
-        <version>0.5.0.62</version>
+        <version>0.5.1.44</version>
         <title>NSClient++</title>
         <authors>Michael Medin</authors>
         <owners>Steven Elder,Ash Caire</owners>
@@ -10,7 +10,7 @@
         <projectUrl>http://nsclient.org/</projectUrl>
         <projectSourceUrl>https://github.com/mickem/nscp</projectSourceUrl>
         <bugTrackerUrl>https://github.com/mickem/nscp/issues</bugTrackerUrl>
-        <docsUrl>https://docs.nsclient.org/0.5.0/</docsUrl>
+        <docsUrl>https://docs.nsclient.org/0.5.1/</docsUrl>
         <packageSourceUrl>https://github.com/acaire/chocolatey-nscp</packageSourceUrl>
         <iconUrl>https://cdn.rawgit.com/TomOne/various/eeae87a5ffe52336769c65c877aa504b4e854682/nscp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,6 +1,6 @@
 ﻿$packageName = 'NSClient++'
-$url         = 'https://github.com/mickem/nscp/releases/download/0.5.0.62/NSCP-0.5.0.62-Win32.msi'
-$url64       = 'https://github.com/mickem/nscp/releases/download/0.5.0.62/NSCP-0.5.0.62-x64.msi'
+$url         = 'https://github.com/mickem/nscp/releases/download/0.5.1.44/NSCP-0.5.1.44-Win32.msi'
+$url64       = 'https://github.com/mickem/nscp/releases/download/0.5.1.44/NSCP-0.5.1.44-x64.msi'
 
 $packageArgs = @{
   packageName    = $packageName
@@ -9,9 +9,9 @@ $packageArgs = @{
   url64bit       = $url64
   silentArgs     = "/quiet"
   validExitCodes = @(0)
-  checksum       = 'a9503ed8f3c9aa43aeda439ac39b302f155eea59a43c097fa8adb90770ec4c56'
+  checksum       = 'FD26AD092A4956DBF2E6E9DB85A911E49DE9CE49793764AB1A87B80336F30A50'
   checksumType   = 'sha256'
-  checksum64     = '7c5ae04dffd956cfbc6fee80a8fefdbe4f53ca6dbc9901e8995003a1ce75e03e'
+  checksum64     = 'D13C84BFEDA3E84B4E0F7858173A2AE0B1F265C03E5AFF88E1194486FF16A730'
   checksumType64 = 'sha256'
 }
 


### PR DESCRIPTION
Couldn't find a sha hash that matched what you had on 5.0.62 but these are the sha256 values I get from Get-FileHash after downloading the latest msi files from the website.  Needs to be run through a chocolatey test first before uploading to chocolatey.org.